### PR TITLE
Ajax loading support (AjaxManager) for orders/settings

### DIFF
--- a/assets/components/minishop2/js/mgr/orders/orders.panel.js
+++ b/assets/components/minishop2/js/mgr/orders/orders.panel.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-	MODx.load({ xtype: 'minishop2-page-orders'});
-});
-
 miniShop2.page.Orders = function(config) {
 	config = config || {};
 	Ext.applyIf(config,{

--- a/assets/components/minishop2/js/mgr/settings/settings.panel.js
+++ b/assets/components/minishop2/js/mgr/settings/settings.panel.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-	MODx.load({ xtype: 'minishop2-page-settings'});
-});
-
 miniShop2.page.Settings = function(config) {
 	config = config || {};
 	Ext.applyIf(config,{

--- a/core/components/minishop2/controllers/mgr/orders.class.php
+++ b/core/components/minishop2/controllers/mgr/orders.class.php
@@ -19,10 +19,16 @@ class Minishop2OrdersManagerController extends miniShop2MainController {
 		$this->addCss($this->miniShop2->config['cssUrl']. 'mgr/bootstrap.min.css');
 
 		$this->addJavascript(MODX_MANAGER_URL.'assets/modext/util/datetime.js');
-		$this->modx->regClientStartupScript($this->miniShop2->config['jsUrl'].'mgr/misc/ms2.utils.js');
-		$this->modx->regClientStartupScript($this->miniShop2->config['jsUrl'].'mgr/misc/ms2.combo.js');
-		$this->modx->regClientStartupScript($this->miniShop2->config['jsUrl'].'mgr/orders/orders.grid.js');
-		$this->modx->regClientStartupScript($this->miniShop2->config['jsUrl'].'mgr/orders/orders.panel.js');
+		$this->addJavascript($this->miniShop2->config['jsUrl'].'mgr/misc/ms2.utils.js');
+		$this->addJavascript($this->miniShop2->config['jsUrl'].'mgr/misc/ms2.combo.js');
+		$this->addJavascript($this->miniShop2->config['jsUrl'].'mgr/orders/orders.grid.js');
+		$this->addJavascript($this->miniShop2->config['jsUrl'].'mgr/orders/orders.panel.js');
+		$this->addHtml('<script type="text/javascript">
+			Ext.onReady(function() {
+				MODx.load({ xtype: "minishop2-page-orders"});
+			});
+		</script>');
+
 		$this->modx->invokeEvent('msOnManagerCustomCssJs',array('controller' => &$this, 'page' => 'orders'));
 	}
 

--- a/core/components/minishop2/controllers/mgr/settings.class.php
+++ b/core/components/minishop2/controllers/mgr/settings.class.php
@@ -15,14 +15,19 @@ class Minishop2SettingsManagerController extends miniShop2MainController {
 		$this->addCss($this->miniShop2->config['cssUrl']. 'mgr/bootstrap.min.css');
 
 		$this->addJavascript(MODX_MANAGER_URL.'assets/modext/util/datetime.js');
-		$this->modx->regClientStartupScript($this->miniShop2->config['jsUrl'].'mgr/misc/ms2.utils.js');
-		$this->modx->regClientStartupScript($this->miniShop2->config['jsUrl'].'mgr/misc/ms2.combo.js');
-		$this->modx->regClientStartupScript($this->miniShop2->config['jsUrl'].'mgr/settings/delivery.grid.js');
-		$this->modx->regClientStartupScript($this->miniShop2->config['jsUrl'].'mgr/settings/payment.grid.js');
-		$this->modx->regClientStartupScript($this->miniShop2->config['jsUrl'].'mgr/settings/status.grid.js');
-		$this->modx->regClientStartupScript($this->miniShop2->config['jsUrl'].'mgr/settings/vendor.grid.js');
-		$this->modx->regClientStartupScript($this->miniShop2->config['jsUrl'].'mgr/settings/link.grid.js');
-		$this->modx->regClientStartupScript($this->miniShop2->config['jsUrl'].'mgr/settings/settings.panel.js');
+		$this->addJavascript($this->miniShop2->config['jsUrl'].'mgr/misc/ms2.utils.js');
+		$this->addJavascript($this->miniShop2->config['jsUrl'].'mgr/misc/ms2.combo.js');
+		$this->addJavascript($this->miniShop2->config['jsUrl'].'mgr/settings/delivery.grid.js');
+		$this->addJavascript($this->miniShop2->config['jsUrl'].'mgr/settings/payment.grid.js');
+		$this->addJavascript($this->miniShop2->config['jsUrl'].'mgr/settings/status.grid.js');
+		$this->addJavascript($this->miniShop2->config['jsUrl'].'mgr/settings/vendor.grid.js');
+		$this->addJavascript($this->miniShop2->config['jsUrl'].'mgr/settings/link.grid.js');
+		$this->addJavascript($this->miniShop2->config['jsUrl'].'mgr/settings/settings.panel.js');
+		$this->addHtml('<script type="text/javascript">
+			Ext.onReady(function() {
+				MODx.load({ xtype: "minishop2-page-settings"});
+			});
+		</script>');
 		$this->modx->invokeEvent('msOnManagerCustomCssJs',array('controller' => &$this, 'page' => 'settings'));
 	}
 

--- a/core/components/minishop2/index.class.php
+++ b/core/components/minishop2/index.class.php
@@ -25,8 +25,8 @@ abstract class miniShop2MainController extends modExtraManagerController {
 		$this->miniShop2 = new miniShop2($this->modx);
 		
 		$this->modx->regClientCSS($this->miniShop2->config['cssUrl'].'mgr/main.css');
-		$this->modx->regClientStartupScript($this->miniShop2->config['jsUrl'].'mgr/minishop2.js');
-		$this->modx->regClientStartupHTMLBlock('<script type="text/javascript">
+		$this->addJavaScript($this->miniShop2->config['jsUrl'].'mgr/minishop2.js');
+		$this->addHtml('<script type="text/javascript">
 		Ext.onReady(function() {
 			miniShop2.config = '.$this->modx->toJSON($this->miniShop2->config).';
 			miniShop2.config.connector_url = "'.$this->miniShop2->config['connectorUrl'].'";


### PR DESCRIPTION
Adds support for AjaxManager plugin for Orders and Settings pages. Don't forget to add `mnishop2` to `ajaxmanager.namespaces` setting.
