### PR TITLE
Update default.js

### DIFF
--- a/assets/components/minishop2/js/web/default.js
+++ b/assets/components/minishop2/js/web/default.js
@@ -233,7 +233,7 @@ typeof $.fn.jGrowl == 'function' || document.write('<script src="' + miniShop2Co
 		}
 		,initialize: function() {
 			miniShop2.Gallery.setup();
-			if (!$(miniShop2.Gallery.gallery).length) {
+			if ($(miniShop2.Gallery.gallery).length) {
 				miniShop2.$doc.on('click', miniShop2.Gallery.gallery + ' ' + miniShop2.Gallery.thumbnail, function(e) {
 					var src = $(this).attr('href');
 					var href = $(this).data('image');


### PR DESCRIPTION
В коммите была строка:

``` javascript
if (!$(miniShop2.Gallery.gallery).length) return;
```

Т.е. если галереи на странице нету, то ничего не делаем.
Сейчас логика получилась следующая - "если на странице НЕТ галерей, то вешаем нужные события. И, если на странице ЕСТЬ галереи, то ничего не делаем", что, в принципе-то, не правильно :-)
Поэтому fix.
