### PR TITLE
Update default.js

### DIFF
--- a/assets/components/minishop2/js/web/default.js
+++ b/assets/components/minishop2/js/web/default.js
@@ -155,7 +155,7 @@ typeof $.fn.jGrowl == 'function' || document.write('<script src="' + miniShop2Co
 		,setup: function() {
 			miniShop2.Cart.cart = '#msCart';
 			miniShop2.Cart.miniCart = '#msMiniCart';
-			miniShop2.Cart.miniCartNotEmptyClass = 'not_empty';
+			miniShop2.Cart.miniCartNotEmptyClass = 'full';
 			miniShop2.Cart.countInput = 'input[name=count]';
 			miniShop2.Cart.totalWeight = '.ms2_total_weight';
 			miniShop2.Cart.totalCount = '.ms2_total_count';


### PR DESCRIPTION
Сменил класс для полной корзины, потому что в no-js-коммите класс был везде назван как `not_empty` (и в скриптах и css). А сейчас в скриптах `not_empty`, а [css](https://github.com/bezumkin/miniShop2/blob/master/assets/components/minishop2/css/web/default.css#L12-L13) `full`.
