### PR TITLE
Defering tab panel content rendering to prevent render issue

### DIFF
--- a/assets/components/minishop2/js/mgr/product/product.common.js
+++ b/assets/components/minishop2/js/mgr/product/product.common.js
@@ -389,10 +389,6 @@ miniShop2.panel.ProductSettings = function(config) {
 
 	Ext.applyIf(config,{
 		id: 'minishop2-product-settings-panel'
-		,border: false
-		,deferredRender: false
-		,forceLayout: true
-		,anchor: '97%'
 		,stateful: MODx.config.ms2_product_remember_tabs == true
 		,stateEvents: ['tabchange']
 		,getState:function() {return { activeTab:this.items.indexOf(this.getActiveTab())};}


### PR DESCRIPTION
Due to the way ExtJS is used within the manager, some elements (when rendered before being displayed) are badly rendered (in my case the product category tree -- using the default vertical tabs).

Letting the the tabs content being rendered only when switching to tabs did solve the issue (Chrome 33/Linux)
