### PR TITLE
Обновление превью из админки

### DIFF
--- a/core/components/minishop2/processors/mgr/gallery/generate.class.php
+++ b/core/components/minishop2/processors/mgr/gallery/generate.class.php
@@ -27,6 +27,12 @@ class msProductFileGenerateProcessor extends modObjectProcessor {
 				$child->remove();
 			}
 			$file->generateThumbnails();
+			
+			$thumb = $file->getFirstThumbnail();
+			$product = $this->modx->getObject('msProductData',array('id' => $file->product_id));
+			$product->thumb = $thumb['url'];
+			if($product->save())
+				return $this->success();
 		}
 		return $this->success();
 	}


### PR DESCRIPTION
В последней версии minishop2-2.1.7-pl2 возникает проблема: при обновлении превьюшек из админки в таблицу msProductData не заносится новое значение поля thumb.
Добавленные строки кода помогают это сделать.
