### PR TITLE
Fix file name on generate thumbnails

### DIFF
--- a/core/components/minishop2/model/minishop2/msproductfile.class.php
+++ b/core/components/minishop2/model/minishop2/msproductfile.class.php
@@ -122,7 +122,7 @@ class msProductFile extends xPDOSimpleObject {
 	 * @return bool
 	 */
 	public function saveThumbnail($raw_image, $options = array()) {
-		$filename = preg_replace('/\..*$/', '', $this->get('file')) . '.' . $options['f'];
+		$filename = pathinfo($this->get('file'),PATHINFO_FILENAME) . '.' . $options['f'];
 		$path = $this->get('path') . $options['w'] .'x'.$options['h'] .'/';
 
 		/* @var msProductFile $product_file */


### PR DESCRIPTION
Fix file name for thumbnails
If we use file names:
photo.1.jpg
photo.2.jpg
photo.3.jpg

all thumbnails will be "photo.jpg"
