### PR TITLE
Исправление прижатого содержимого окон к его шапке

### DIFF
--- a/assets/components/minishop2/js/mgr/misc/default.window.js
+++ b/assets/components/minishop2/js/mgr/misc/default.window.js
@@ -4,7 +4,7 @@ miniShop2.window.Default = function(config) {
     Ext.applyIf(config, {
         title: '',
         url: miniShop2.config['connector_url'],
-        cls: 'modx-window minishop2-window ' || config['cls'],
+        cls: 'minishop2-window ' || config['cls'],
         width: 600,
         autoHeight: true,
         allowDrop: false,


### PR DESCRIPTION
### Что оно делает?

Удаляет css класс `modx-window` у которого `padding-top` убран на 0

### Зачем это нужно?

![image](https://user-images.githubusercontent.com/20814058/84280468-87fe7880-ab61-11ea-9310-0fda199a0e31.png)
