### PR TITLE
Added appstat resolver

### DIFF
--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -55,4 +55,5 @@ $BUILD_RESOLVERS = [
     'chunks',
     'statuses',
     'setup',
+    'modappstat',
 ];

--- a/_build/resolvers/resolve.modappstat.php
+++ b/_build/resolvers/resolve.modappstat.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * modAppStat Resolver v2.0
+ */
+
+$package = $options['namespace'];
+$url     = 'https://communitystat.modapps.pro/api/v1/';
+$params  = array();
+
+$modx =& $object->xpdo;
+$c = $modx->newQuery('transport.modTransportPackage');
+$c->where(
+    array(
+        'workspace' => 1,
+        "(SELECT
+            `signature`
+            FROM {$modx->getTableName('modTransportPackage')} AS `latestPackage`
+            WHERE `latestPackage`.`package_name` = `modTransportPackage`.`package_name`
+            ORDER BY
+                `latestPackage`.`version_major` DESC,
+                `latestPackage`.`version_minor` DESC,
+                `latestPackage`.`version_patch` DESC,
+                IF(`release` = '' OR `release` = 'ga' OR `release` = 'pl','z',`release`) DESC,
+                `latestPackage`.`release_index` DESC
+                LIMIT 1,1) = `modTransportPackage`.`signature`",
+    )
+);
+$c->where(
+    array(
+        array(
+            'modTransportPackage.package_name' => strtolower($package)
+        ),
+        'installed:IS NOT' => null
+    )
+);
+$c->limit(1);
+
+/** @var modTransportPackage $oldPackage */
+$oldPackage = $modx->getObject('transport.modTransportPackage', $c);
+
+$oldVersion = '';
+if ($oldPackage) {
+    $oldVersion = $oldPackage->get('version_major') . '.' . $oldPackage->get('version_minor');
+    $oldVersion .= '.' . $oldPackage->get('version_patch');
+    $oldVersion .= '-' . $oldPackage->get('release');
+}
+
+$version = '';
+if ($options['topic']) {
+    $topic     = trim($options['topic'], '/');
+    $topic     = explode('/', $topic);
+    $signature = end($topic);
+    $version   = str_replace(strtolower($package) . '-', '', $signature);
+}
+
+$modxVersionObj = $modx->getObject('modSystemSetting', array('key' => 'settings_version'));
+$modxVersion    = ($modxVersionObj) ? $modxVersionObj->get('value') : '';
+$managerLang    = $modx->getOption('manager_language');
+
+$action = '';
+switch ($options[xPDOTransport::PACKAGE_ACTION]) {
+    case xPDOTransport::ACTION_INSTALL:
+        $action = 'install';
+        break;
+    case xPDOTransport::ACTION_UPGRADE:
+        $action = 'upgrade';
+        break;
+    case xPDOTransport::ACTION_UNINSTALL:
+        $action = 'uninstall';
+
+        $version          = $oldVersion;
+        $setupOptionsPath = explode('/', $options['setup-options']);
+        $signature        = $setupOptionsPath[0];
+        $oldVersion       = str_replace(strtolower($package) . '-', '', $signature);
+
+        break;
+}
+
+$params = array(
+    'name'                 => $options['namespace'],
+    'url'                  => $_SERVER['SERVER_NAME'],
+    'php_version'          => phpversion(),
+    'modx_version'         => $modxVersion,
+    'manager_lang'         => $managerLang,
+    'installation_type'    => $action,
+    'package_version_from' => $oldVersion,
+    'package_version'      => $version,
+    'date'                 => time()
+);
+
+/**
+ * Curl POST.
+ */
+$curl = curl_init();
+curl_setopt($curl, CURLOPT_URL, $url);
+curl_setopt($curl, CURLOPT_HTTPHEADER, array('Authorization: MODX-RSCHARDCODEDPASS'));
+curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 120);
+curl_setopt($curl, CURLOPT_POST, true);
+curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($params));
+curl_setopt($curl, CURLOPT_TIMEOUT, 120);
+
+$response     = curl_exec($curl);
+$responseInfo = curl_getinfo($curl);
+$curlError    = curl_error($curl);
+curl_close($curl);
+
+return true;


### PR DESCRIPTION
### Что оно делает?

Добавлен резолвер для сбора community stat

### Зачем это нужно?

Статистика позволит улучшить продукт (minishop2) на основе данных.
Собираются только:
Версия пакета, которая устанавливается или удаляется
Версия, с которой обновляется пакет
Версия MODX, PHP и язык админки.

### Пара скриншотов
Установка:
![2023-04-20_15-14-08](https://user-images.githubusercontent.com/5102558/233364238-00527482-b347-43f1-8fa5-17f07058049e.png)

Обновление (на примере другого пакета):
![photo_2023-04-20_15-21-09](https://user-images.githubusercontent.com/5102558/233364260-07cec02f-6424-4060-aeaf-ac3cf7ac541b.jpg)

Решение проверено в течение 30 дней на почти десятке пакетов. Скриншоты выкладывал в telegram-сообществе.
