### PR TITLE
В методы add, change. remove класса msCartHandler добавлены данные об изменении кол-ва товара

### DIFF
--- a/core/components/minishop2/handlers/interfaces/msCartInterface.php
+++ b/core/components/minishop2/handlers/interfaces/msCartInterface.php
@@ -11,7 +11,7 @@ interface msCartInterface
      *
      * @return boolean
      */
-    public function initialize($ctx = 'web');
+    public function initialize(string $ctx = 'web'): bool;
 
     /**
      * Adds product to cart
@@ -22,7 +22,7 @@ interface msCartInterface
      *
      * @return array|string $response
      */
-    public function add($id, $count = 1, $options = []);
+    public function add(int $id, int $count = 1, array $options = []);
 
     /**
      * Removes product from cart
@@ -31,7 +31,7 @@ interface msCartInterface
      *
      * @return array|string $response
      */
-    public function remove($key);
+    public function remove(string $key);
 
     /**
      * Changes products count in cart
@@ -41,7 +41,7 @@ interface msCartInterface
      *
      * @return array|string $response
      */
-    public function change($key, $count);
+    public function change(string $key, int $count);
 
     /**
      * Cleans the cart
@@ -57,14 +57,14 @@ interface msCartInterface
      *
      * @return array $status
      */
-    public function status($data = []);
+    public function status(array $data = []): array;
 
     /**
      * Returns the cart items
      *
      * @return array $cart
      */
-    public function get();
+    public function get(): array;
 
     /**
      * Set all the cart items by one array
@@ -73,5 +73,5 @@ interface msCartInterface
      *
      * @return void
      */
-    public function set($cart = []);
+    public function set(array $cart = []): void;
 }

--- a/core/components/minishop2/handlers/mscarthandler.class.php
+++ b/core/components/minishop2/handlers/mscarthandler.class.php
@@ -56,7 +56,7 @@ class msCartHandler implements msCartInterface
      *
      * @return bool
      */
-    public function initialize($ctx = 'web') : bool
+    public function initialize(string $ctx = 'web') : bool
     {
         $ms2_cart_context = (bool)$this->modx->getOption('ms2_cart_context', null, '0', true);
         if ($ms2_cart_context) {
@@ -74,7 +74,7 @@ class msCartHandler implements msCartInterface
      *
      * @return array|string
      */
-    public function add($id, $count = 1, $options = [])
+    public function add(int $id, int $count = 1, array $options = [])
     {
         if (empty($id) || !is_numeric($id)) {
             return $this->error('ms2_cart_add_err_id');
@@ -183,7 +183,7 @@ class msCartHandler implements msCartInterface
      *
      * @return array|string
      */
-    public function remove($key)
+    public function remove(string $key)
     {
         if (!array_key_exists($key, $this->cart)) {
             return $this->error('ms2_cart_remove_error');
@@ -221,7 +221,7 @@ class msCartHandler implements msCartInterface
      *
      * @return array|string
      */
-    public function change($key, $count)
+    public function change(string $key, int $count)
     {
         if (!array_key_exists($key, $this->cart)) {
             return $this->error('ms2_cart_change_error', $this->status());
@@ -296,7 +296,7 @@ class msCartHandler implements msCartInterface
      *
      * @return array
      */
-    public function status($data = []): array
+    public function status(array $data = []): array
     {
         $status = [
             'total_count' => 0,
@@ -345,7 +345,7 @@ class msCartHandler implements msCartInterface
     /**
      * @param array $cart
      */
-    public function set($cart = []) : void
+    public function set(array $cart = []) : void
     {
         $this->cart = $this->storageHandler->set($cart);
     }
@@ -353,7 +353,7 @@ class msCartHandler implements msCartInterface
     /**
      * Set controller for Cart
      */
-    protected function storageInit()
+    protected function storageInit(): void
     {
         switch ($this->storage) {
             case 'session':

--- a/core/components/minishop2/handlers/mscarthandler.class.php
+++ b/core/components/minishop2/handlers/mscarthandler.class.php
@@ -56,7 +56,7 @@ class msCartHandler implements msCartInterface
      *
      * @return bool
      */
-    public function initialize($ctx = 'web')
+    public function initialize($ctx = 'web') : bool
     {
         $ms2_cart_context = (bool)$this->modx->getOption('ms2_cart_context', null, '0', true);
         if ($ms2_cart_context) {
@@ -164,12 +164,15 @@ class msCartHandler implements msCartInterface
             return $this->error($response['message']);
         }
 
+        $changes = $this->getChanges('add', $count, 0);
+
         return $this->success(
             'ms2_cart_add_success',
             $this->status([
                 'key' => $key,
                 'cart' => $this->cart,
-                'row' => $this->cart[$key]
+                'row' => $this->cart[$key],
+                'changes' => $changes
             ]),
             ['count' => $count]
         );
@@ -186,6 +189,8 @@ class msCartHandler implements msCartInterface
             return $this->error('ms2_cart_remove_error');
         }
 
+        $product = $this->cart[$key];
+
         $response = $this->ms2->invokeEvent('msOnBeforeRemoveFromCart', ['key' => $key, 'cart' => $this]);
         if (!$response['success']) {
             return $this->error($response['message']);
@@ -198,11 +203,14 @@ class msCartHandler implements msCartInterface
             return $this->error($response['message']);
         }
 
+        $changes = $this->getChanges('remove',0, $product['count']);
+
         return $this->success(
             'ms2_cart_remove_success',
             $this->status([
                 'cart' => $this->cart,
-                'row' => $row
+                'row' => $row,
+                'changes' => $changes
             ])
         );
     }
@@ -215,9 +223,8 @@ class msCartHandler implements msCartInterface
      */
     public function change($key, $count)
     {
-        $status = [];
         if (!array_key_exists($key, $this->cart)) {
-            return $this->error('ms2_cart_change_error', $this->status($status));
+            return $this->error('ms2_cart_change_error', $this->status());
         }
 
         if ($count <= 0) {
@@ -237,6 +244,9 @@ class msCartHandler implements msCartInterface
         }
 
         $count = $response['data']['count'];
+
+        $changes = $this->getChanges('change', $count, $this->cart[$key]['count']);
+
         $this->cart = $this->storageHandler->change($key, $count);
         $response = $this->ms2->invokeEvent(
             'msOnChangeInCart',
@@ -245,10 +255,14 @@ class msCartHandler implements msCartInterface
         if (!$response['success']) {
             return $this->error($response['message']);
         }
-        $status['key'] = $key;
-        $status['cost'] = $count * $this->cart[$key]['price'];
-        $status['cart'] = $this->cart;
-        $status['row'] = $this->cart[$key];
+
+        $status = [
+            'key' => $key,
+            'cost' => $count * $this->cart[$key]['price'],
+            'cart' => $this->cart,
+            'row' => $this->cart[$key],
+            'changes' => $changes
+        ];
 
         return $this->success(
             'ms2_cart_change_success',
@@ -282,7 +296,7 @@ class msCartHandler implements msCartInterface
      *
      * @return array
      */
-    public function status($data = [])
+    public function status($data = []): array
     {
         $status = [
             'total_count' => 0,
@@ -316,7 +330,7 @@ class msCartHandler implements msCartInterface
     /**
      * @return array
      */
-    public function get()
+    public function get() : array
     {
         $cart = [];
         foreach ($this->cart as $key => $item) {
@@ -331,7 +345,7 @@ class msCartHandler implements msCartInterface
     /**
      * @param array $cart
      */
-    public function set($cart = [])
+    public function set($cart = []) : void
     {
         $this->cart = $this->storageHandler->set($cart);
     }
@@ -362,7 +376,7 @@ class msCartHandler implements msCartInterface
      *
      * @return array|string
      */
-    public function error($message = '', $data = [], $placeholders = [])
+    public function error(string $message = '', array $data = [], array $placeholders = [])
     {
         return $this->ms2->error($message, $data, $placeholders);
     }
@@ -376,7 +390,7 @@ class msCartHandler implements msCartInterface
      *
      * @return array|string
      */
-    public function success($message = '', $data = [], $placeholders = [])
+    public function success(string $message = '', array $data = [], array $placeholders = [])
     {
         return $this->ms2->success($message, $data, $placeholders);
     }
@@ -389,7 +403,7 @@ class msCartHandler implements msCartInterface
      * @return string
      *
      */
-    protected function getProductKey(array $product, array $options = [])
+    protected function getProductKey(array $product, array $options = []): string
     {
         $key_fields = explode(',', $this->config['cart_product_key_fields']);
         $product['options'] = $options;
@@ -406,5 +420,15 @@ class msCartHandler implements msCartInterface
         }
 
         return 'ms' . md5($key);
+    }
+
+    protected function getChanges(string $method, int $count, int $oldCount): array
+    {
+        return [
+            'method' => $method,
+            'count' => $count,
+            'old_count' => $oldCount,
+            'delta' => $count - $oldCount
+        ];
     }
 }


### PR DESCRIPTION
### Что оно делает?

Методы add, change, remove класса msCartHandler возвращают на фронт много информации, такой как текущая корзина, общая стоимость товаров и их вес и другое.
Но нет информации о том, сколько товара было в корзине ДО совершения действия. 
Например: в корзине было 2 единицы товара, и мы добавили еще один. В ответе от сервере будет count = 3. Но для различных ситуаций может потребоваться информация о том, сколько товаров было ДО совершения действия (2 товара). Самый простой пример - это передача данных в системы электронной коммерции.

Это изменение добавляет новый ключ `changes` в ответ сервера:
<img width="1032" height="397" alt="image" src="https://github.com/user-attachments/assets/8f460463-0ebb-46e0-9415-4661a5448338" />

`change` содержит в себе:
 - `count` - текущее кол-во товара в корзине
 - `old_count` - прошлое кол-во товара
 - `delta` - разница между `count`  и `old_count`
 - `method` - метод, который был вызван (add, change, remove)

### Зачем это нужно?
На фронте будет доступно больше данных об изменениях после выполнения действий (add, change, remove) с товарами в корзине. 

### Связанные проблема(ы)/PR(ы)

https://github.com/modx-pro/miniShop2/issues/908