### PR TITLE
Исправлена ошибка при использовании плагина на событие msOnBeforeChangeOrderStatus

### DIFF
--- a/core/components/minishop2/docs/changelog.txt
+++ b/core/components/minishop2/docs/changelog.txt
@@ -6,7 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [4.4.2-pl] - 2025-09-29
+
+### Fixed
 - Fixed 'remains' and 'reserved' fields
+- Fixed order status null
+
+### Added
+- Add new filters for orders dashboard
+
 
 ## [4.4.1-pl] - 2025-09-22
 

--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -2,7 +2,7 @@
 
 class miniShop2
 {
-    public $version = '4.4.0-pl';
+    public $version = '4.4.2-pl';
     /** @var modX $modx */
     public $modx;
     /** @var pdoFetch $pdoTools */
@@ -821,6 +821,7 @@ class miniShop2
             return $this->modx->lexicon($error);
         }
 
+        $old_status_id = null;
         /** @var msOrderStatus $old_status */
         $old_status = $this->modx->getObject(
             'msOrderStatus',
@@ -837,7 +838,9 @@ class miniShop2
                     return $this->modx->lexicon($error);
                 }
             }
+            $old_status_id = $old_status->get('id');
         }
+
         if ($order->get('status') == $status_id) {
             $error = 'ms2_err_status_same';
             return $this->modx->lexicon($error);
@@ -845,7 +848,7 @@ class miniShop2
 
         $response = $this->invokeEvent('msOnBeforeChangeOrderStatus', [
             'order' => $order,
-            'old_status' => $old_status->get('id'),
+            'old_status' => $old_status_id,
             'status' => $status_id,
         ]);
         if (!$response['success']) {
@@ -858,7 +861,7 @@ class miniShop2
             $this->orderLog($order->get('id'), 'status', $status_id);
             $response = $this->invokeEvent('msOnChangeOrderStatus', [
                 'order' => $order,
-                'old_status' => $old_status->get('id'),
+                'old_status' => $old_status_id,
                 'status' => $status_id,
             ]);
             if (!$response['success']) {


### PR DESCRIPTION
### Что оно делает?

Добавлена проверка получения предыдущего статуса при измнении статуса или создании заказа. Проявлялась при использовании плагина на события 
msOnBeforeChangeOrderStatus или msOnChangeOrderStatus


### Связанные проблема(ы)/PR(ы)

#950 